### PR TITLE
Added an NCL script to create SCRIP format grid description file

### DIFF
--- a/NCLtomakeSCRIP.ncl
+++ b/NCLtomakeSCRIP.ncl
@@ -27,7 +27,7 @@ begin  ;input parameter section
    
     ;file name (latlonfile) and directory path (inputdir)for the input file, which 
     ;contains lat, lon, and optionally masking arrays
-    inputdir ="/global/cfs/cdirs/m2637/ksa/hadgem2-es/mon"  
+    inputdir ="/global/cfs/cdirs/m2637/ksa/HadGEM2-ES/mon"  
     latlonfile = "ua_Amon_HadGEM2-ES_historical_r1i1p1_195912-198411.nc"
     
     ; more details about the target grid    

--- a/NCLtomakeSCRIP.ncl
+++ b/NCLtomakeSCRIP.ncl
@@ -32,11 +32,26 @@ inputdir ="/global/cfs/cdirs/m2637/ksa/HadGEM2-ES/mon"
 latlonfile = "ua_Amon_HadGEM2-ES_historical_r1i1p1_195912-198411.nc"
 
 ; more details about the target grid    
-latname =  "lat" ; name of the variable lat in latlonfile
-lonname =  "lon" ; name of the variable lon in latlonfile
-GridType   = "rectilinear" ; "latlon", "unstructured"; "curvilinear" ; "rectilinear"
-;see this website for description:
+latname =  "lat" ; name of the variable lat in the latlonfile
+lonname =  "lon" ; name of the variable lon in the latlonfile
+
+GridType   = "rectilinear" ; choose from:
+;"rectilinear" 
+; most common grids described by one-dimensional latitude and longitude coordinates
+; https://www.ncl.ucar.edu/Document/glossary.shtml#R
+
+;"curvilinear" ; 
+; grids often used by regional models and satellites data where the coordinates are two-dimensional 
+; https://www.ncl.ucar.edu/Document/glossary.shtml#CurvilinearGrid
+
+;"unstructured"
+; not a typical 2-d grids in which grd boxes are ordered following the lat and lon coordinates
+; instead the grid coordinates require a list of nodes (connectivity information) 
+;https://www.ncl.ucar.edu/Document/glossary.shtml#UnstructuredGrid
+
+;see these websites for more information about different types of grids
 ; https://climatedataguide.ucar.edu/climate-tools/regridding-overview
+
 
 isegional = False ; regional grid or not; False for global grid
 
@@ -131,11 +146,7 @@ end if
 
 print("running ESMF function")
 ; run the ESMF functions, defined for different types of grid
-if(GridType .eq. "latlon") then   ; uniform lat&lon grid, need to provide grid type
-     print("calling latlon_to_SCRIP")
-     latlon_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),latlongridname,ESMFOpt) 
-     
-else if( GridType .eq. "rectilinear") then   ; non-uniform (can be) lat&lon grid
+if( GridType .eq. "rectilinear") then   ; non-uniform (can be) lat&lon grid
      print("calling rectilinear_to_SCRIP")
      rectilinear_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,ESMFOpt)
      
@@ -145,9 +156,7 @@ else if( GridType .eq. "curvilinear") then  ;---If we have 2D lat/lon arrays.
      
 else if( GridType .eq. "unstructured") then ;unstructured grids. Only SE mesh.
      unstructured_to_ESMF((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,ESMFOpt)
-     
-end if
-end if
+     end if
 end if
 end if
 

--- a/NCLtomakeSCRIP.ncl
+++ b/NCLtomakeSCRIP.ncl
@@ -16,7 +16,9 @@
 
 ; on NERSC systems, NCL is not available as a single module.
 ; instead, load the climate-utils module, which makes NCL Version 6.6.2 available
-; %module load climate-utils
+; then invoke the NCL command along with this script name:
+; $> module load climate-utils
+; $> ncl NCLtomakeSCRIP.ncl
 ;----------------------------------------------------------------------
 load "$NCARG_ROOT/lib/ncarg/nclscripts/esmf/ESMF_regridding.ncl"
 

--- a/NCLtomakeSCRIP.ncl
+++ b/NCLtomakeSCRIP.ncl
@@ -21,54 +21,54 @@
 load "$NCARG_ROOT/lib/ncarg/nclscripts/esmf/ESMF_regridding.ncl"
 
 
-begin  ;input parameter section
-    ;;;; parameters to specify the input file ;;;;;
-    gridname = "HadGEM2-ES_2deg"  ; I usualy gives a descrptive name for the grid   
-   
-    ;file name (latlonfile) and directory path (inputdir)for the input file, which 
-    ;contains lat, lon, and optionally masking arrays
-    inputdir ="/global/cfs/cdirs/m2637/ksa/HadGEM2-ES/mon"  
-    latlonfile = "ua_Amon_HadGEM2-ES_historical_r1i1p1_195912-198411.nc"
-    
-    ; more details about the target grid    
-    latname =  "lat" ; name of the variable lat in latlonfile
-    lonname =  "lon" ; name of the variable lon in latlonfile
-    GridType   = "rectilinear" ; "latlon", "unstructured"; "curvilinear" ; "rectilinear"
-    ;see this website for description:
-    ; https://climatedataguide.ucar.edu/climate-tools/regridding-overview
-    
-    isegional = False ; regional grid or not; False for global grid
-    
-    
-    
-    ;directory path, where to save the new SCRIP file for the target grid 
-    tgtSCRIPdir ="/pscratch/sd/k/ksa/temp/esmf"
-    
-    ;output SCRIP file name. 
-    tgtSCRIPfile = ("SCRIP_" + gridname + ".nc")
-     
-    
-    ;static missing data points?
-    MissingData = False           
-    MaskName_user = "NA" ;if True, what would be an appropriate name for the mask?
-    ;MaskName = "landmask"
-    
-    ;note that for missing values changing with time, we need a different approach to regrid
-    ; in that case I don't create static masks.
-    ; https://nco.sourceforge.net/nco.html#index-_005fFillValue
-    ; https://www.ncl.ucar.edu/Applications/ESMF.shtml#WeightsAndMasking
-    
-    if(MissingData) then
-        MaskName = MaskName_user
-        tgtSCRIPfile = ("SCRIP_" + gridname + "_" + MaskName + ".nc")
-    else
-        MaskName = default_fillvalue("string")
-    end if
+;;;; parameters to specify the input file ;;;;;
+gridname = "HadGEM2-ES_2deg"  ; I usualy gives a descrptive name for the grid   
 
-end
+;file name (latlonfile) and directory path (inputdir)for the input file, which 
+;contains lat, lon, and optionally masking arrays
+inputdir ="/global/cfs/cdirs/m2637/ksa/HadGEM2-ES/mon"  
+latlonfile = "ua_Amon_HadGEM2-ES_historical_r1i1p1_195912-198411.nc"
+
+; more details about the target grid    
+latname =  "lat" ; name of the variable lat in latlonfile
+lonname =  "lon" ; name of the variable lon in latlonfile
+GridType   = "rectilinear" ; "latlon", "unstructured"; "curvilinear" ; "rectilinear"
+;see this website for description:
+; https://climatedataguide.ucar.edu/climate-tools/regridding-overview
+
+isegional = False ; regional grid or not; False for global grid
+
+;directory path, where to save the new SCRIP file for the target grid 
+tgtSCRIPdir ="/pscratch/sd/k/ksa/temp/esmf"
+
+;output SCRIP file name. 
+tgtSCRIPfile = ("SCRIP_" + gridname + ".nc")
+ 
+
+;static missing data points?
+MissingData = False           
+MaskName_user = "NA" ;if True, what would be an appropriate name for the mask?
+;MaskName = "landmask"
+
+;note that for missing values changing with time, we need a different approach to regrid
+; in that case I don't create static masks.
+; https://nco.sourceforge.net/nco.html#index-_005fFillValue
+; https://www.ncl.ucar.edu/Applications/ESMF.shtml#WeightsAndMasking
+
+if(MissingData) then
+    MaskName = MaskName_user
+    tgtSCRIPfile = ("SCRIP_" + gridname + "_" + MaskName + ".nc")
+else
+    MaskName = default_fillvalue("string")
+end if
+
+
 ;----------------------------------------------------------------------
 ;  Generate a description file (SCRIP) for the target grid.
 ;----------------------------------------------------------------------
+
+print("gridname : " + gridname)
+
 ESMFOpt                = True
 ESMFOpt@ForceOverwrite = True
 ESMFOpt@Overwrite       = True
@@ -80,6 +80,8 @@ sfile = addfile((inputdir + "/" + latlonfile),"r")
 
 if(MissingData) then ; Necessary if x has STATIC missing values.
     ;change the output file name
+    print("taking care of static missing masks")
+
     tgtSCRIPfile = ("SCRIP_" + tgtres + "_" + MaskName + ".nc")
     
     ;an example for for ERA5 land-sea mask
@@ -123,6 +125,9 @@ else
         ilon := rm_single_dims(ilon) 
     end if
     
+end if
+
+print("running ESMF function")
 ; run the ESMF functions, defined for different types of grid
 if(GridType .eq. "latlon") then   ; uniform lat&lon grid, need to provide grid type
      print("calling latlon_to_SCRIP")

--- a/NCLtomakeSCRIP.ncl
+++ b/NCLtomakeSCRIP.ncl
@@ -1,196 +1,147 @@
 ;----------------------------------------------------------------------
+; this script reads in a file that contains latitude, longitude, and potentially
+; an array of masks for missing data points (e.g., land/ocean, land water point, etc)
+; for a given horizontal grid.
+
+; NCL basics: https://www.ncl.ucar.edu/Document/Manuals/Getting_Started/basics.shtml
+; NCL is an interpreted langugage, similar to Matlab and Xarray-loaded python
+; It has most of the functions provided by Xarray (e.g., coordinate subscritions,
+; data models with coordinates and metadata, good support for netcdf and other file formats, etc.)
+; and a lot of functions tailored for weather/climate sciences and for WRF/CESM outputs
+; https://www.ncl.ucar.edu/Document/Functions/
+
+; and notably regridding functions including those from the ESMF library
 ; http://www.ncl.ucar.edu/Applications/ESMF.shtml
+; Koichi Sakaguchi, Koichi.Sakaguchi@pnnl.gov
+
+; on NERSC systems, NCL is not available as a single module.
+; instead, load the climate-utils module, which makes NCL Version 6.6.2 available
+; %module load climate-utils
 ;----------------------------------------------------------------------
 load "$NCARG_ROOT/lib/ncarg/nclscripts/esmf/ESMF_regridding.ncl"
 
 
-begin
+begin  ;input parameter section
     ;;;; parameters to specify the input file ;;;;;
-    tgtres = "HadGEM2-ES_2deg"  ;   
+    gridname = "HadGEM2-ES_2deg"  ; I usualy gives a descrptive name for the grid   
    
-
-    ;where to save SCRIP files for src
-    ;tgtSCRIPdir ="/global/cfs/cdirs/m1660/ksa/regrid"  
-    ;tgtSCRIPdir = "/global/cfs/cdirs/m1867/ksa/NCL/wgtFiles"
-    tgtSCRIPdir ="/global/cfs/cdirs/m2637/ksa/gridmaps"
-    ;tgtSCRIPdir ="/global/cfs/cdirs/m1867/ksa/NCL/wgtFiles";"/glade/u/home/ksa/dca/mapping"
-    ;tgtSCRIPdir = "/global/cfs/cdirs/m1867/MPASinput/mp32-4a/rotated_1830914_4-32km_Tibet"
-    
-    ;output SCRIP file name
-    tgtSCRIPfile = ("SCRIP_" + tgtres + ".nc")
-    ;tgtSCRIPfile = ("SCRIP_" + tgtres + "_watermask.nc")
-    ;tgtSCRIPfile = ("SCRIP_" + tgtres + "_lndmask.nc")
-    
-   
-    latlondir ="/global/cfs/cdirs/m2637/ksa/hadgem2-es/mon"  
+    ;file name (latlonfile) and directory path (inputdir)for the input file, which 
+    ;contains lat, lon, and optionally masking arrays
+    inputdir ="/global/cfs/cdirs/m2637/ksa/hadgem2-es/mon"  
     latlonfile = "ua_Amon_HadGEM2-ES_historical_r1i1p1_195912-198411.nc"
     
-  
-    ; more details about the source grid    
-    isegional = False ; regional grid or not (src); False for global grid
+    ; more details about the target grid    
+    latname =  "lat" ; name of the variable lat in latlonfile
+    lonname =  "lon" ; name of the variable lon in latlonfile
+    GridType   = "rectilinear" ; "latlon", "unstructured"; "curvilinear" ; "rectilinear"
+    ;see this website for description:
+    ; https://climatedataguide.ucar.edu/climate-tools/regridding-overview
+    
+    isegional = False ; regional grid or not; False for global grid
+    
+    
+    
+    ;directory path, where to save the new SCRIP file for the target grid 
+    tgtSCRIPdir ="/pscratch/sd/k/ksa/temp/esmf"
+    
+    ;output SCRIP file name. 
+    tgtSCRIPfile = ("SCRIP_" + gridname + ".nc")
+     
     
     ;static missing data points?
-    MissingData = False       
-    
-    ;if True, what would be an appropriate name for the mask?
-    MaskName = default_fillvalue("string")
+    MissingData = False           
+    MaskName_user = "NA" ;if True, what would be an appropriate name for the mask?
     ;MaskName = "landmask"
-       
     
-    latname =  "lat" ; name of the variable lat in srcFileSample
-    lonname =  "lon" ; name of the variable lon in srcFileSample
-    GridType   = "rectilinear" ; "latlon", "unstructured"; "curvilinear" ; "rectilinear"
-      ;capture the time and date to be included in the global attributes
-
-   ;;for quick check of statistics
-   dopt = True
-   dopt@PrintStat = True
-
-   TimeDate = systemfunc("date")
+    ;note that for missing values changing with time, we need a different approach to regrid
+    ; in that case I don't create static masks.
+    ; https://nco.sourceforge.net/nco.html#index-_005fFillValue
+    ; https://www.ncl.ucar.edu/Applications/ESMF.shtml#WeightsAndMasking
+    
+    if(MissingData) then
+        MaskName = MaskName_user
+        tgtSCRIPfile = ("SCRIP_" + gridname + "_" + MaskName + ".nc")
+    else
+        MaskName = default_fillvalue("string")
+    end if
 
 end
 ;----------------------------------------------------------------------
-;  Generate a description file (SCRIP) for the source grid.
+;  Generate a description file (SCRIP) for the target grid.
 ;----------------------------------------------------------------------
-SrcOpt                = True
-SrcOpt@ForceOverwrite = True
-SrcOpt@Overwrite       = True
-SrcOpt@PrintTimings   = True
-SrcOpt@Debug          = True
+ESMFOpt                = True
+ESMFOpt@ForceOverwrite = True
+ESMFOpt@Overwrite       = True
+ESMFOpt@PrintTimings   = True
+ESMFOpt@Debug          = True
 
-if(latlonfile .ne. "none") then
-    sfile = addfile((latlondir + "/" + latlonfile),"r")
-else
-    if ( tgtres .eq. "HISCALE_d01_v1_rectilinear" ) then
-        gridfile = ("/global/cfs/cdirs/m1660/ksa/simulations/common/0830_test03_wrfinput_d01")
-        f = addfile(gridfile,"r")
-        xlat = f->XLAT(0,:,:)
-        xlon = f->XLONG(0,:,:)    
-        delete(f)        
-    end if
+sfile = addfile((inputdir + "/" + latlonfile),"r") 
+;read the input netcdf file and create a file object sfile
 
-    if ( tgtres .eq. "HISCALE_d02_v1_rectilinear" ) then
-        gridfile = ("/global/cfs/cdirs/m1660/ksa/simulations/common/0830_test03_wrfinput_d02")
-        f = addfile(gridfile,"r")
-        xlat = f->XLAT(0,:,:)
-        xlon = f->XLONG(0,:,:)    
-        delete(f)        
-    end if
-    
-end if
-
-
-
-if(MissingData) then ; Necessary if x has missing values.
+if(MissingData) then ; Necessary if x has STATIC missing values.
     ;change the output file name
     tgtSCRIPfile = ("SCRIP_" + tgtres + "_" + MaskName + ".nc")
     
-    ;for OAFlux
-    if(tgtres .eq. "OAFlux_1deg") then
-        svar  = rm_single_dims(sfile->evapr(0,:,:))  
-        vscale = doubletofloat(svar@scale_factor)
-        svar := short2flt(svar)
-
-        misval = svar@missing_value_original
-        delete(svar@missing_value)
-    
-        svar@_FillValue = doubletofloat(misval)*vscale
-        istat = stat_dispersion(svar , dopt )  
-        
-        itemp = where(.not.ismissing(svar), 1 , 0) 
-        copy_VarCoords(svar,itemp)
-                
-    end if
-    
-
-    ;for ERA5
-    if(tgtres .eq. "ERA5_0.25deg") then
+    ;an example for for ERA5 land-sea mask
+    if(gridname .eq. "ERA5_0.25deg") then
+        ;read an example variable with missing values 
         svar  = rm_single_dims(sfile->LSM(0,:,:))  ; do not include time or vertical dimensions
         
         if(MaskName .eq. "ocnmask") then
-            itemp = svar
+            itemp = svar ; oceanmask
         else
             itemp = where(svar .lt. 1.0, 1 , 0) 
-            copy_VarCoords(svar,itemp)
+            copy_VarCoords(svar,itemp)  ;landmask
         end if
         
     end if
     
-    ;for SMAPDA
-    if(tgtres .eq. "SMAPDA_lgdom_1km") then
-        svar  = sfile->Qle_tavg  ; do not include time or vertical dimensions
-        
-        if(MaskName .eq. "ocnmask") then
-            itemp = svar
-        else
-            itemp = where(ismissing(svar), 1 , 0) 
-            copy_VarCoords(svar,itemp)
-        end if
-        
-    end if
     
-    ;for OSU-SM
-    if(tgtres .eq. "osu_sm_800m") then
-        svar  = sfile->vwc(0,0,:,:)  ; do not include time or vertical dimensions
-        
-        itemp = where(ismissing(svar), 1 , 0) 
-        copy_VarCoords(svar,itemp)
-        
-    end if
-    
-    ;for CPC_US with ocean mask
-    if(tgtres .eq. "CPC_US") then
-        svar  = sfile->precip(0,:,:)  ; do not include time or vertical dimensions       
-        
-        itemp = where(ismissing(svar), 1 , 0) 
-        copy_VarCoords(svar,itemp)
-        
-    end if
-    
-    SrcOpt@GridMask  = itemp     
+    ESMFOpt@GridMask  = itemp     
     
 end if
 ;warning:NetOpenFile: MissingToFillValue option set True, but missing_value attribute and data variable (evapr) types differ: not adding virtual _FillValue attribute
-if ( isStrSubset(tgtres, "_rectilinear" )) then
-    ilat = dim_avg_n(xlat,1)
-    ilon = dim_avg_n(xlon,0)
-    
-    
-else if(tgtres .eq. "SMAPDA_lgdom_1km") then
-    ;the SMAP-DA lat and lon are 2d arrays, but idential in one dimension
-    ; so essentially just 1d arrays for rectinilinear grid
-    ilat:= dim_avg_n_Wrap(sfile->$srclatname$,1)
-    ilon:= dim_avg_n_Wrap(sfile->$ilonname$,0)
+; read in the latitude and longitude arrays 
+ilat = sfile->$latname$
+ilon = sfile->$lonname$
 
-else if(tgtres .eq. "wrf_NAM-22_6hr") then
-    ;remove time dimension
-    ilat:= ilat(0,:,:)
-    ilon:= ilon(0,:,:)
+sdims = dimsizes(ilat)
+ndims = dimsizes(sdims)
 
+; need to remove any unecessary dimensions
+; such as time in the WRF output
+; assuming such additional dimensions has a size of 1
+
+if(GridType .eq. "curvilinear") 
+    if (ndims .gt. 2) then
+        ilat := rm_single_dims(ilat) ; the ":=" operate overwrites the variable
+        ilon := rm_single_dims(ilon) 
+    end if
 else
-    ilat = rm_single_dims(sfile->$latname$)
-    ilon = rm_single_dims(sfile->$lonname$)
-end if
-end if
-end if
-
-
+    if(ndims .gt. 1) then
+        ilat := rm_single_dims(ilat) 
+        ilon := rm_single_dims(ilon) 
+    end if
+    
+; run the ESMF functions, defined for different types of grid
 if(GridType .eq. "latlon") then   ; uniform lat&lon grid, need to provide grid type
      print("calling latlon_to_SCRIP")
-     latlon_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),latlongridname,SrcOpt) 
+     latlon_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),latlongridname,ESMFOpt) 
      
 else if( GridType .eq. "rectilinear") then   ; non-uniform (can be) lat&lon grid
      print("calling rectilinear_to_SCRIP")
-     rectilinear_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,SrcOpt)
+     rectilinear_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,ESMFOpt)
      
 else if( GridType .eq. "curvilinear") then  ;---If we have 2D lat/lon arrays.
      print("calling curvilinear_to_SCRIP")
-     curvilinear_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,SrcOpt)
+     curvilinear_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,ESMFOpt)
      
 else if( GridType .eq. "unstructured") then ;unstructured grids. Only SE mesh.
-     unstructured_to_ESMF((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,SrcOpt)
+     unstructured_to_ESMF((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,ESMFOpt)
      
 end if
 end if
 end if
 end if
+
+;that's it

--- a/NCLtomakeSCRIP.ncl
+++ b/NCLtomakeSCRIP.ncl
@@ -1,0 +1,196 @@
+;----------------------------------------------------------------------
+; http://www.ncl.ucar.edu/Applications/ESMF.shtml
+;----------------------------------------------------------------------
+load "$NCARG_ROOT/lib/ncarg/nclscripts/esmf/ESMF_regridding.ncl"
+
+
+begin
+    ;;;; parameters to specify the input file ;;;;;
+    tgtres = "HadGEM2-ES_2deg"  ;   
+   
+
+    ;where to save SCRIP files for src
+    ;tgtSCRIPdir ="/global/cfs/cdirs/m1660/ksa/regrid"  
+    ;tgtSCRIPdir = "/global/cfs/cdirs/m1867/ksa/NCL/wgtFiles"
+    tgtSCRIPdir ="/global/cfs/cdirs/m2637/ksa/gridmaps"
+    ;tgtSCRIPdir ="/global/cfs/cdirs/m1867/ksa/NCL/wgtFiles";"/glade/u/home/ksa/dca/mapping"
+    ;tgtSCRIPdir = "/global/cfs/cdirs/m1867/MPASinput/mp32-4a/rotated_1830914_4-32km_Tibet"
+    
+    ;output SCRIP file name
+    tgtSCRIPfile = ("SCRIP_" + tgtres + ".nc")
+    ;tgtSCRIPfile = ("SCRIP_" + tgtres + "_watermask.nc")
+    ;tgtSCRIPfile = ("SCRIP_" + tgtres + "_lndmask.nc")
+    
+   
+    latlondir ="/global/cfs/cdirs/m2637/ksa/hadgem2-es/mon"  
+    latlonfile = "ua_Amon_HadGEM2-ES_historical_r1i1p1_195912-198411.nc"
+    
+  
+    ; more details about the source grid    
+    isegional = False ; regional grid or not (src); False for global grid
+    
+    ;static missing data points?
+    MissingData = False       
+    
+    ;if True, what would be an appropriate name for the mask?
+    MaskName = default_fillvalue("string")
+    ;MaskName = "landmask"
+       
+    
+    latname =  "lat" ; name of the variable lat in srcFileSample
+    lonname =  "lon" ; name of the variable lon in srcFileSample
+    GridType   = "rectilinear" ; "latlon", "unstructured"; "curvilinear" ; "rectilinear"
+      ;capture the time and date to be included in the global attributes
+
+   ;;for quick check of statistics
+   dopt = True
+   dopt@PrintStat = True
+
+   TimeDate = systemfunc("date")
+
+end
+;----------------------------------------------------------------------
+;  Generate a description file (SCRIP) for the source grid.
+;----------------------------------------------------------------------
+SrcOpt                = True
+SrcOpt@ForceOverwrite = True
+SrcOpt@Overwrite       = True
+SrcOpt@PrintTimings   = True
+SrcOpt@Debug          = True
+
+if(latlonfile .ne. "none") then
+    sfile = addfile((latlondir + "/" + latlonfile),"r")
+else
+    if ( tgtres .eq. "HISCALE_d01_v1_rectilinear" ) then
+        gridfile = ("/global/cfs/cdirs/m1660/ksa/simulations/common/0830_test03_wrfinput_d01")
+        f = addfile(gridfile,"r")
+        xlat = f->XLAT(0,:,:)
+        xlon = f->XLONG(0,:,:)    
+        delete(f)        
+    end if
+
+    if ( tgtres .eq. "HISCALE_d02_v1_rectilinear" ) then
+        gridfile = ("/global/cfs/cdirs/m1660/ksa/simulations/common/0830_test03_wrfinput_d02")
+        f = addfile(gridfile,"r")
+        xlat = f->XLAT(0,:,:)
+        xlon = f->XLONG(0,:,:)    
+        delete(f)        
+    end if
+    
+end if
+
+
+
+if(MissingData) then ; Necessary if x has missing values.
+    ;change the output file name
+    tgtSCRIPfile = ("SCRIP_" + tgtres + "_" + MaskName + ".nc")
+    
+    ;for OAFlux
+    if(tgtres .eq. "OAFlux_1deg") then
+        svar  = rm_single_dims(sfile->evapr(0,:,:))  
+        vscale = doubletofloat(svar@scale_factor)
+        svar := short2flt(svar)
+
+        misval = svar@missing_value_original
+        delete(svar@missing_value)
+    
+        svar@_FillValue = doubletofloat(misval)*vscale
+        istat = stat_dispersion(svar , dopt )  
+        
+        itemp = where(.not.ismissing(svar), 1 , 0) 
+        copy_VarCoords(svar,itemp)
+                
+    end if
+    
+
+    ;for ERA5
+    if(tgtres .eq. "ERA5_0.25deg") then
+        svar  = rm_single_dims(sfile->LSM(0,:,:))  ; do not include time or vertical dimensions
+        
+        if(MaskName .eq. "ocnmask") then
+            itemp = svar
+        else
+            itemp = where(svar .lt. 1.0, 1 , 0) 
+            copy_VarCoords(svar,itemp)
+        end if
+        
+    end if
+    
+    ;for SMAPDA
+    if(tgtres .eq. "SMAPDA_lgdom_1km") then
+        svar  = sfile->Qle_tavg  ; do not include time or vertical dimensions
+        
+        if(MaskName .eq. "ocnmask") then
+            itemp = svar
+        else
+            itemp = where(ismissing(svar), 1 , 0) 
+            copy_VarCoords(svar,itemp)
+        end if
+        
+    end if
+    
+    ;for OSU-SM
+    if(tgtres .eq. "osu_sm_800m") then
+        svar  = sfile->vwc(0,0,:,:)  ; do not include time or vertical dimensions
+        
+        itemp = where(ismissing(svar), 1 , 0) 
+        copy_VarCoords(svar,itemp)
+        
+    end if
+    
+    ;for CPC_US with ocean mask
+    if(tgtres .eq. "CPC_US") then
+        svar  = sfile->precip(0,:,:)  ; do not include time or vertical dimensions       
+        
+        itemp = where(ismissing(svar), 1 , 0) 
+        copy_VarCoords(svar,itemp)
+        
+    end if
+    
+    SrcOpt@GridMask  = itemp     
+    
+end if
+;warning:NetOpenFile: MissingToFillValue option set True, but missing_value attribute and data variable (evapr) types differ: not adding virtual _FillValue attribute
+if ( isStrSubset(tgtres, "_rectilinear" )) then
+    ilat = dim_avg_n(xlat,1)
+    ilon = dim_avg_n(xlon,0)
+    
+    
+else if(tgtres .eq. "SMAPDA_lgdom_1km") then
+    ;the SMAP-DA lat and lon are 2d arrays, but idential in one dimension
+    ; so essentially just 1d arrays for rectinilinear grid
+    ilat:= dim_avg_n_Wrap(sfile->$srclatname$,1)
+    ilon:= dim_avg_n_Wrap(sfile->$ilonname$,0)
+
+else if(tgtres .eq. "wrf_NAM-22_6hr") then
+    ;remove time dimension
+    ilat:= ilat(0,:,:)
+    ilon:= ilon(0,:,:)
+
+else
+    ilat = rm_single_dims(sfile->$latname$)
+    ilon = rm_single_dims(sfile->$lonname$)
+end if
+end if
+end if
+
+
+if(GridType .eq. "latlon") then   ; uniform lat&lon grid, need to provide grid type
+     print("calling latlon_to_SCRIP")
+     latlon_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),latlongridname,SrcOpt) 
+     
+else if( GridType .eq. "rectilinear") then   ; non-uniform (can be) lat&lon grid
+     print("calling rectilinear_to_SCRIP")
+     rectilinear_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,SrcOpt)
+     
+else if( GridType .eq. "curvilinear") then  ;---If we have 2D lat/lon arrays.
+     print("calling curvilinear_to_SCRIP")
+     curvilinear_to_SCRIP((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,SrcOpt)
+     
+else if( GridType .eq. "unstructured") then ;unstructured grids. Only SE mesh.
+     unstructured_to_ESMF((tgtSCRIPdir + "/" + tgtSCRIPfile),ilat,ilon,SrcOpt)
+     
+end if
+end if
+end if
+end if


### PR DESCRIPTION
The NCL script NCLtomakeSCRIP.ncl creates a grid description file in the so-called SCRIP format.
Such a file is necessary to use the ESMF regridding function, namely the "ESMF_RegridWeightGen" executable, run in the accompanying shell script "run_module_RegridWeightGen.sh".